### PR TITLE
Add DisabledExtensions CA regsitry value

### DIFF
--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -722,6 +722,7 @@ namespace Sharphound.Runtime {
                 var enrollmentAgentRestrictionsCollected = false;
                 var isUserSpecifiesSanEnabledCollected = false;
                 var roleSeparationEnabledCollected = false;
+                var disabledExtensionsCollected = false;
                 var caName = entry.GetProperty(LDAPProperties.Name);
                 var dnsHostName = entry.GetProperty(LDAPProperties.DNSHostName);
                 if (caName != null && dnsHostName != null) {
@@ -744,6 +745,7 @@ namespace Sharphound.Runtime {
                         EnrollmentAgentRestrictions = await _certAbuseProcessor.ProcessEAPermissions(caName,
                             resolvedSearchResult.Domain, dnsHostName, ret.HostingComputer),
                         RoleSeparationEnabled = _certAbuseProcessor.RoleSeparationEnabled(dnsHostName, caName),
+                        DisabledExtensions = _certAbuseProcessor.DisabledExtensions(dnsHostName, caName),
 
                         // The CASecurity exist in the AD object DACL and in registry of the CA server. We prefer to use the values from registry as they are the ground truth.
                         // If changes are made on the CA server, registry and the AD object is updated. If changes are made directly on the AD object, the CA server registry is not updated.
@@ -755,6 +757,7 @@ namespace Sharphound.Runtime {
                     enrollmentAgentRestrictionsCollected = cARegistryData.EnrollmentAgentRestrictions.Collected;
                     isUserSpecifiesSanEnabledCollected = cARegistryData.IsUserSpecifiesSanEnabled.Collected;
                     roleSeparationEnabledCollected = cARegistryData.RoleSeparationEnabled.Collected;
+                    disabledExtensionsCollected = cARegistryData.DisabledExtensions.Collected;
                     ret.CARegistryData = cARegistryData;
                 } else {
                     _log.LogWarning("The CA name or dnsHostname properties are null.");
@@ -764,6 +767,7 @@ namespace Sharphound.Runtime {
                 ret.Properties.Add("enrollmentagentrestrictionscollected", enrollmentAgentRestrictionsCollected);
                 ret.Properties.Add("isuserspecifiessanenabledcollected", isUserSpecifiesSanEnabledCollected);
                 ret.Properties.Add("roleseparationenabledcollected", roleSeparationEnabledCollected);
+                ret.Properties.Add("disabledextensionscollected", disabledExtensionsCollected);
             }
 
             return ret;


### PR DESCRIPTION
## Description

The corresponding PR for this commonlib PR: https://github.com/SpecterOps/SharpHoundCommon/pull/236 

## Motivation and Context

See commonlib PR.

## How Has This Been Tested?

Locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Certificate authority registry details now include information about disabled certificate extensions.
  * Added a status indicator showing whether disabled-extension information was collected successfully.
  * This provides clearer visibility into the availability and completeness of disabled-extension data when reviewing certificate authority records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->