### PR TITLE
Add RPC encryption CA reg key

### DIFF
--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -767,6 +767,7 @@ namespace Sharphound.Runtime {
                 var enrollmentAgentRestrictionsCollected = false;
                 var isUserSpecifiesSanEnabledCollected = false;
                 var roleSeparationEnabledCollected = false;
+                var rPCEncryptionCollected = false;
                 var caName = entry.GetProperty(LDAPProperties.Name);
                 var dnsHostName = entry.GetProperty(LDAPProperties.DNSHostName);
                 if (caName != null && dnsHostName != null) {
@@ -789,6 +790,7 @@ namespace Sharphound.Runtime {
                         EnrollmentAgentRestrictions = await _certAbuseProcessor.ProcessEAPermissions(caName,
                             resolvedSearchResult.Domain, dnsHostName, ret.HostingComputer),
                         RoleSeparationEnabled = _certAbuseProcessor.RoleSeparationEnabled(dnsHostName, caName),
+                        RPCEncryptionEnforced = _certAbuseProcessor.RPCEncryptionEnforced(dnsHostName, caName),
 
                         // The CASecurity exist in the AD object DACL and in registry of the CA server. We prefer to use the values from registry as they are the ground truth.
                         // If changes are made on the CA server, registry and the AD object is updated. If changes are made directly on the AD object, the CA server registry is not updated.
@@ -800,6 +802,7 @@ namespace Sharphound.Runtime {
                     enrollmentAgentRestrictionsCollected = cARegistryData.EnrollmentAgentRestrictions.Collected;
                     isUserSpecifiesSanEnabledCollected = cARegistryData.IsUserSpecifiesSanEnabled.Collected;
                     roleSeparationEnabledCollected = cARegistryData.RoleSeparationEnabled.Collected;
+                    rPCEncryptionCollected = cARegistryData.RPCEncryptionEnforced.Collected;
                     ret.CARegistryData = cARegistryData;
                 } else {
                     _log.LogWarning("The CA name or dnsHostname properties are null.");
@@ -809,6 +812,7 @@ namespace Sharphound.Runtime {
                 ret.Properties.Add("enrollmentagentrestrictionscollected", enrollmentAgentRestrictionsCollected);
                 ret.Properties.Add("isuserspecifiessanenabledcollected", isUserSpecifiesSanEnabledCollected);
                 ret.Properties.Add("roleseparationenabledcollected", roleSeparationEnabledCollected);
+                ret.Properties.Add("rpcencryptioncollected", rPCEncryptionCollected);
             }
 
             return ret;


### PR DESCRIPTION
## Description

Collection of additional CA reg key value (RPC encryption enforcement) 

## Motivation and Context

This change is required for ADCS ESC11 coverage.

Corresponding SHC PR: https://github.com/SpecterOps/SharpHoundCommon/pull/239
Corresponding BHCE PR: https://github.com/SpecterOps/BloodHound/pull/1679

Resolves BED-6182

## How Has This Been Tested?

Locally in lab.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added collection and display of RPC encryption enforcement status for Certificate Authorities.
  * Added reporting to indicate whether RPC encryption enforcement data was successfully collected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->