### PR TITLE
Feature: Add collection of Active Directory Sites ACLs and data

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The listing below details the CLI arguments SharpHound supports. Additional deta
 ```
   -c, --collectionmethods    (Default: Default) Collection Methods: Container, Group, LocalGroup, GPOLocalGroup,
                              Session, LoggedOn, ObjectProps, ACL, ComputerOnly, Trusts, Default, RDP, DCOM, DCOnly, UserRights, 
-                             CARegistry, DCRegistry, CertServices, WebClientService, NTLMRegistry,SMBInfo,LdapServices
+                             CARegistry, DCRegistry, CertServices, Site, WebClientService, NTLMRegistry, SMBInfo, LdapServices
 
   -d, --domain               Specify domain to enumerate
 

--- a/src/Client/Enums.cs
+++ b/src/Client/Enums.cs
@@ -31,6 +31,7 @@
         LdapServices,
         SmbInfo,
         NTLMRegistry,
+        Site,
         // Re-introduce this when we're ready for Event Log collection
         // EventLogs,
         All

--- a/src/Options.cs
+++ b/src/Options.cs
@@ -208,6 +208,7 @@ namespace Sharphound
                     CollectionMethodOptions.LdapServices => CollectionMethod.LdapServices,
                     CollectionMethodOptions.SmbInfo => CollectionMethod.SmbInfo,
                     CollectionMethodOptions.NTLMRegistry => CollectionMethod.NTLMRegistry,
+                    CollectionMethodOptions.Site => CollectionMethod.Site,
                     // Re-introduce this when we're ready for Event Log collection
                     // CollectionMethodOptions.EventLogs => CollectionMethod.EventLogs,
                     CollectionMethodOptions.All => CollectionMethod.All,

--- a/src/Options.cs
+++ b/src/Options.cs
@@ -14,7 +14,7 @@ namespace Sharphound
         // Options that affect what is collected
         [Option('c', "collectionmethods", Default = new[] { "Default" },
             HelpText =
-                "Collection Methods: Group, LocalGroup, LocalAdmin, RDP, DCOM, PSRemote, Session, Trusts, ACL, Container, ComputerOnly, GPOLocalGroup, LoggedOn, ObjectProps, SPNTargets, UserRights, Default, DCOnly, CARegistry, DCRegistry, CertServices, WebClientService, LdapServices, SmbInfo, NTLMRegistry, All")]
+                "Collection Methods: Group, LocalGroup, LocalAdmin, RDP, DCOM, PSRemote, Session, Trusts, ACL, Container, ComputerOnly, GPOLocalGroup, LoggedOn, ObjectProps, SPNTargets, UserRights, Default, DCOnly, CARegistry, DCRegistry, CertServices, Site, WebClientService, LdapServices, SmbInfo, NTLMRegistry, All")]
         public IEnumerable<string> CollectionMethods { get; set; }
 
         [Option('d', "domain", Default = null, HelpText = "Specify domain to enumerate")]

--- a/src/PowerShell/Template.ps1
+++ b/src/PowerShell/Template.ps1
@@ -30,12 +30,13 @@
             LoggedOn - Collect session information using privileged methods (needs admin!)
             ObjectProps - Collect node property information for users and computers
             SPNTargets - Collect SPN targets (currently only MSSQL)
-            Default - Collect Group Membership, Local Admin, Sessions, Containers, ACLs, Domain Trusts, and ADCS objects
-            DcOnly - Collect Group Membership, ACLs, ObjectProps, Trusts, Containers, GPO Admins, and ADCS objects
+            Default - Collect Group Membership, Local Admin, Sessions, Containers, ACLs, Domain Trusts, ADCS objects, and AD sites
+            DcOnly - Collect Group Membership, ACLs, ObjectProps, Trusts, Containers, GPO Admins, ADCS objects, and AD sites
             UserRights - Collect User Rights Assignment from domain computers (needs admin)
             CARegistry - Collect ADCS properties from registry of Certificate Authority servers
             DCRegistry - Collect properties from registry of Domain Controller servers
             CertServices - Collect ADCS objects from Certificate Services
+            Site - Collect AD site, site server, and site subnet data
             All - Collect all data
 
         This can be a list of comma separated valued as well to run multiple collection methods!

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -39,6 +39,7 @@ namespace Sharphound.Runtime {
         private readonly SPNProcessors _spnProcessor;
         private readonly WebClientServiceProcessor _webClientProcessor;
         private readonly SmbProcessor _smbProcessor;
+        private readonly SiteProcessor _siteProcessor;
         private readonly ConcurrentDictionary<string, RegistryProcessor> _registryProcessorMap = new();
         public ObjectProcessors(IContext context, ILogger log) {
             _context = context;
@@ -60,6 +61,7 @@ namespace Sharphound.Runtime {
             _localGroupProcessor = new LocalGroupProcessor(context.LDAPUtils);
             _webClientProcessor = new WebClientServiceProcessor(log);
             _smbProcessor = new SmbProcessor(context.PortScanTimeout);
+            _siteProcessor = new SiteProcessor(context.LDAPUtils);
             _methods = context.ResolvedCollectionMethods;
             _cancellationToken = context.CancellationTokenSource.Token;
             _log = log;
@@ -95,6 +97,12 @@ namespace Sharphound.Runtime {
                     return await ProcessCertTemplate(entry, resolvedSearchResult);
                 case Label.IssuancePolicy:
                     return await ProcessIssuancePolicy(entry, resolvedSearchResult);
+                case Label.Site:
+                    return await ProcessSiteObject(entry, resolvedSearchResult);
+                case Label.SiteServer:
+                    return await ProcessSiteServerObject(entry, resolvedSearchResult);
+                case Label.SiteSubnet:
+                    return await ProcessSiteSubnetObject(entry, resolvedSearchResult);
                 case Label.Base:
                     return null;
                 default:
@@ -920,6 +928,126 @@ namespace Sharphound.Runtime {
 
             if (_methods.HasFlag(CollectionMethod.Container) || _methods.HasFlag(CollectionMethod.CertServices)) {
                 if (await _containerProcessor.GetContainingObject(entry) is (true, var container)) {
+                    ret.ContainedBy = container;
+                }
+            }
+
+            return ret;
+        }
+
+        private async Task<Site> ProcessSiteObject(IDirectoryObject entry,
+            ResolvedSearchResult resolvedSearchResult)
+        {
+            var ret = new Site
+            {
+                ObjectIdentifier = resolvedSearchResult.ObjectId
+            };
+
+            ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
+
+            if (_methods.HasFlag(CollectionMethod.ACL))
+            {
+                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
+                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
+                ret.Aces = aces;
+                ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
+                ret.Properties.Add("isaclprotected", ret.IsACLProtected);
+            }
+
+            if (_methods.HasFlag(CollectionMethod.ObjectProps))
+            {
+                ret.Properties =
+                    ContextUtils.Merge(LdapPropertyProcessor.ReadSiteProperties(entry), ret.Properties);
+                if (_context.Flags.CollectAllProperties)
+                {
+                    ret.Properties = ContextUtils.Merge(_ldapPropertyProcessor.ParseAllProperties(entry),
+                        ret.Properties);
+                }
+            }
+
+            ret.Links = await _siteProcessor.ReadSiteGPLinks(resolvedSearchResult, entry).ToArrayAsync();
+
+            return ret;
+        }
+
+        private async Task<SiteServer> ProcessSiteServerObject(IDirectoryObject entry,
+            ResolvedSearchResult resolvedSearchResult)
+        {
+            var ret = new SiteServer
+            {
+                ObjectIdentifier = resolvedSearchResult.ObjectId
+            };
+
+            ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
+
+            
+            if (await _siteProcessor.GetContainingSiteForServer(entry) is (true, var container))
+            {
+                ret.ContainedBy = container;
+            }
+            
+            if (_methods.HasFlag(CollectionMethod.ACL))
+            {
+                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
+                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
+                ret.Aces = aces;
+                ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
+                ret.Properties.Add("isaclprotected", ret.IsACLProtected);
+            }
+
+            if (_methods.HasFlag(CollectionMethod.ObjectProps))
+            {
+                ret.Properties =
+                    ContextUtils.Merge(LdapPropertyProcessor.ReadSiteServerProperties(entry), ret.Properties);
+                if (_context.Flags.CollectAllProperties)
+                {
+                    ret.Properties = ContextUtils.Merge(_ldapPropertyProcessor.ParseAllProperties(entry),
+                        ret.Properties);
+                }
+            }
+
+            return ret;
+        }
+
+        private async Task<SiteSubnet> ProcessSiteSubnetObject(IDirectoryObject entry,
+            ResolvedSearchResult resolvedSearchResult)
+        {
+            var ret = new SiteSubnet
+            {
+                ObjectIdentifier = resolvedSearchResult.ObjectId
+            };
+
+            ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
+
+            if (_methods.HasFlag(CollectionMethod.ACL))
+            {
+                var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
+                    .ToArrayAsync(cancellationToken: _cancellationToken);
+                ret.Properties.Add("doesanyacegrantownerrights", aces.Any(ace => ace.IsPermissionForOwnerRightsSid));
+                ret.Properties.Add("doesanyinheritedacegrantownerrights", aces.Any(ace => ace.IsInheritedPermissionForOwnerRightsSid));
+                ret.Aces = aces;
+                ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
+                ret.Properties.Add("isaclprotected", ret.IsACLProtected);
+            }
+            
+            if (_methods.HasFlag(CollectionMethod.ObjectProps))
+            {
+                ret.Properties =
+                    ContextUtils.Merge(LdapPropertyProcessor.ReadSiteSubnetProperties(entry), ret.Properties);
+                if (_context.Flags.CollectAllProperties)
+                {
+                    ret.Properties = ContextUtils.Merge(_ldapPropertyProcessor.ParseAllProperties(entry),
+                        ret.Properties);
+                }
+
+                // Can only deduce containing site for a subnet if we read the object properties, including siteObject
+
+                if (await _siteProcessor.GetContainingSiteForSubnet(ret.Properties) is (true, var container))
+                {
                     ret.ContainedBy = container;
                 }
             }

--- a/src/Runtime/ObjectProcessors.cs
+++ b/src/Runtime/ObjectProcessors.cs
@@ -974,7 +974,7 @@ namespace Sharphound.Runtime {
 
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
-            if (_methods.HasFlag(CollectionMethod.ACL))
+            if (_methods.HasFlag(CollectionMethod.ACL) || _methods.HasFlag(CollectionMethod.Site))
             {
                 var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
                     .ToArrayAsync(cancellationToken: _cancellationToken);
@@ -983,9 +983,10 @@ namespace Sharphound.Runtime {
                 ret.Aces = aces;
                 ret.IsACLProtected = _aclProcessor.IsACLProtected(entry);
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
+                ret.InheritanceHashes = _aclProcessor.GetInheritedAceHashes(entry, resolvedSearchResult).ToArray();
             }
 
-            if (_methods.HasFlag(CollectionMethod.ObjectProps))
+            if (_methods.HasFlag(CollectionMethod.ObjectProps) || _methods.HasFlag(CollectionMethod.Site))
             {
                 ret.Properties =
                     ContextUtils.Merge(LdapPropertyProcessor.ReadSiteProperties(entry), ret.Properties);
@@ -996,7 +997,16 @@ namespace Sharphound.Runtime {
                 }
             }
 
-            ret.Links = await _siteProcessor.ReadSiteGPLinks(resolvedSearchResult, entry).ToArrayAsync();
+            if (_methods.HasFlag(CollectionMethod.Container) || _methods.HasFlag(CollectionMethod.Site)) {
+                if (await _containerProcessor.GetContainingObject(entry) is (true, var container)) {
+                    ret.ContainedBy = container;
+                }
+            }
+
+            if (_methods.HasFlag(CollectionMethod.Site))
+            {
+                ret.Links = await _siteProcessor.ReadSiteGPLinks(resolvedSearchResult, entry).ToArrayAsync();            
+            }
 
             return ret;
         }
@@ -1010,14 +1020,8 @@ namespace Sharphound.Runtime {
             };
 
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
-
             
-            if (await _siteProcessor.GetContainingSiteForServer(entry) is (true, var container))
-            {
-                ret.ContainedBy = container;
-            }
-            
-            if (_methods.HasFlag(CollectionMethod.ACL))
+            if (_methods.HasFlag(CollectionMethod.ACL) || _methods.HasFlag(CollectionMethod.Site))
             {
                 var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
                     .ToArrayAsync(cancellationToken: _cancellationToken);
@@ -1028,7 +1032,7 @@ namespace Sharphound.Runtime {
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
 
-            if (_methods.HasFlag(CollectionMethod.ObjectProps))
+            if (_methods.HasFlag(CollectionMethod.ObjectProps) || _methods.HasFlag(CollectionMethod.Site))
             {
                 ret.Properties =
                     ContextUtils.Merge(LdapPropertyProcessor.ReadSiteServerProperties(entry), ret.Properties);
@@ -1036,6 +1040,20 @@ namespace Sharphound.Runtime {
                 {
                     ret.Properties = ContextUtils.Merge(_ldapPropertyProcessor.ParseAllProperties(entry),
                         ret.Properties);
+                }
+            }
+
+            if (_methods.HasFlag(CollectionMethod.Container) || _methods.HasFlag(CollectionMethod.Site)) {
+                if (await _siteProcessor.GetContainingSiteForServer(entry) is (true, var container))
+                {
+                    ret.ContainedBy = container;
+                }
+            }
+
+            if (_methods.HasFlag(CollectionMethod.Site)) {
+                if (await _siteProcessor.GetReferencedComputerForServer(entry) is (true, var server))
+                {
+                    ret.ServerIs = server;
                 }
             }
 
@@ -1052,7 +1070,7 @@ namespace Sharphound.Runtime {
 
             ret.Properties = new Dictionary<string, object>(GetCommonProperties(entry, resolvedSearchResult));
 
-            if (_methods.HasFlag(CollectionMethod.ACL))
+            if (_methods.HasFlag(CollectionMethod.ACL) || _methods.HasFlag(CollectionMethod.Site))
             {
                 var aces = await _aclProcessor.ProcessACL(resolvedSearchResult, entry, true)
                     .ToArrayAsync(cancellationToken: _cancellationToken);
@@ -1063,7 +1081,7 @@ namespace Sharphound.Runtime {
                 ret.Properties.Add("isaclprotected", ret.IsACLProtected);
             }
             
-            if (_methods.HasFlag(CollectionMethod.ObjectProps))
+            if (_methods.HasFlag(CollectionMethod.ObjectProps) || _methods.HasFlag(CollectionMethod.Container) || _methods.HasFlag(CollectionMethod.Site))
             {
                 ret.Properties =
                     ContextUtils.Merge(LdapPropertyProcessor.ReadSiteSubnetProperties(entry), ret.Properties);
@@ -1074,7 +1092,6 @@ namespace Sharphound.Runtime {
                 }
 
                 // Can only deduce containing site for a subnet if we read the object properties, including siteObject
-
                 if (await _siteProcessor.GetContainingSiteForSubnet(ret.Properties) is (true, var container))
                 {
                     ret.ContainedBy = container;

--- a/src/Runtime/OutputWriter.cs
+++ b/src/Runtime/OutputWriter.cs
@@ -216,7 +216,7 @@ namespace Sharphound.Runtime
                 _containerOutput.GetFilename(), _domainOutput.GetFilename(), _gpoOutput.GetFilename(),
                 _ouOutput.GetFilename(), _rootCAOutput.GetFilename(), _aIACAOutput.GetFilename(),
                 _enterpriseCAOutput.GetFilename(), _nTAuthStoreOutput.GetFilename(),
-                _certTemplateOutput.GetFilename(),_issuancePolicyOutput.GetFilename(),
+                _certTemplateOutput.GetFilename(), _issuancePolicyOutput.GetFilename(),
                 _siteOutput.GetFilename(), _siteServerOutput.GetFilename(), _siteSubnetOutput.GetFilename(),
             });
 

--- a/src/Runtime/OutputWriter.cs
+++ b/src/Runtime/OutputWriter.cs
@@ -1,19 +1,18 @@
-﻿using ICSharpCode.SharpZipLib.Core;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using System.Timers;
+using ICSharpCode.SharpZipLib.Core;
 using ICSharpCode.SharpZipLib.Zip;
 using Microsoft.Extensions.Logging;
 using Sharphound.Client;
 using Sharphound.Writers;
 using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.OutputTypes;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.DirectoryServices;
-using System.IO;
-using System.Linq;
-using System.Threading.Channels;
-using System.Threading.Tasks;
-using System.Timers;
 
 namespace Sharphound.Runtime
 {
@@ -166,6 +165,7 @@ namespace Sharphound.Runtime
                 }
             }
 
+            Console.WriteLine("Closing writers");
             return await FlushWriters();
         }
 

--- a/src/Runtime/OutputWriter.cs
+++ b/src/Runtime/OutputWriter.cs
@@ -1,18 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Threading.Channels;
-using System.Threading.Tasks;
-using System.Timers;
-using ICSharpCode.SharpZipLib.Core;
+﻿using ICSharpCode.SharpZipLib.Core;
 using ICSharpCode.SharpZipLib.Zip;
 using Microsoft.Extensions.Logging;
 using Sharphound.Client;
 using Sharphound.Writers;
 using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.OutputTypes;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.DirectoryServices;
+using System.IO;
+using System.Linq;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using System.Timers;
 
 namespace Sharphound.Runtime
 {
@@ -34,6 +35,9 @@ namespace Sharphound.Runtime
         private readonly JsonDataWriter<NTAuthStore> _nTAuthStoreOutput;
         private readonly JsonDataWriter<CertTemplate> _certTemplateOutput;
         private readonly JsonDataWriter<IssuancePolicy> _issuancePolicyOutput;
+        private readonly JsonDataWriter<Site> _siteOutput;
+        private readonly JsonDataWriter<SiteServer> _siteServerOutput;
+        private readonly JsonDataWriter<SiteSubnet> _siteSubnetOutput;
 
 
         private int _completedCount;
@@ -57,6 +61,9 @@ namespace Sharphound.Runtime
             _nTAuthStoreOutput = new JsonDataWriter<NTAuthStore>(_context, DataType.NTAuthStores);
             _certTemplateOutput = new JsonDataWriter<CertTemplate>(_context, DataType.CertTemplates);
             _issuancePolicyOutput = new JsonDataWriter<IssuancePolicy>(_context, DataType.IssuancePolicies);
+            _siteOutput = new JsonDataWriter<Site>(_context, DataType.Sites);
+            _siteServerOutput = new JsonDataWriter<SiteServer>(_context, DataType.SiteServers);
+            _siteSubnetOutput = new JsonDataWriter<SiteSubnet>(_context, DataType.SiteSubnets);
 
             _runTimer = new Stopwatch();
             _statusTimer = new Timer(_context.StatusInterval);
@@ -145,12 +152,20 @@ namespace Sharphound.Runtime
                     case IssuancePolicy issuancePolicy:
                         await _issuancePolicyOutput.AcceptObject(issuancePolicy);
                         break;
+                    case Site site:
+                        await _siteOutput.AcceptObject(site);
+                        break;
+                    case SiteServer siteServer:
+                        await _siteServerOutput.AcceptObject(siteServer);
+                        break;
+                    case SiteSubnet siteSubnet:
+                        await _siteSubnetOutput.AcceptObject(siteSubnet);
+                        break;
                     default:
                         throw new ArgumentOutOfRangeException(nameof(item));
                 }
             }
 
-            Console.WriteLine("Closing writers");
             return await FlushWriters();
         }
 
@@ -169,6 +184,9 @@ namespace Sharphound.Runtime
             await _nTAuthStoreOutput.FlushWriter();
             await _certTemplateOutput.FlushWriter();
             await _issuancePolicyOutput.FlushWriter();
+            await _siteOutput.FlushWriter();
+            await _siteServerOutput.FlushWriter();
+            await _siteSubnetOutput.FlushWriter();
             CloseOutput();
             var fileName = ZipFiles();
             return fileName;
@@ -198,7 +216,8 @@ namespace Sharphound.Runtime
                 _containerOutput.GetFilename(), _domainOutput.GetFilename(), _gpoOutput.GetFilename(),
                 _ouOutput.GetFilename(), _rootCAOutput.GetFilename(), _aIACAOutput.GetFilename(),
                 _enterpriseCAOutput.GetFilename(), _nTAuthStoreOutput.GetFilename(),
-                _certTemplateOutput.GetFilename(),_issuancePolicyOutput.GetFilename()
+                _certTemplateOutput.GetFilename(),_issuancePolicyOutput.GetFilename(),
+                _siteOutput.GetFilename(), _siteServerOutput.GetFilename(), _siteSubnetOutput.GetFilename(),
             });
 
             foreach (var entry in fileList.Where(x => !string.IsNullOrEmpty(x)))


### PR DESCRIPTION
## Description

This pull requests aims to integrate Active Directory Sites into the data collected from the configuration partition.
This pull request goes with the following Bloodhound PR: https://github.com/SpecterOps/BloodHound/pull/2031
It is also accompanied by the following SharpHoundCommon PR: https://github.com/SpecterOps/SharpHoundCommon/pull/257
A more complete description on why we thought this could be a good idea is described in details in the BloodHound PR, as well as the following article that we just released: https://www.synacktiv.com/en/publications/site-unseen-enumerating-and-attacking-active-directory-sites


## Motivation and Context

Motivation and context are explained in the linked article.

Tickets: BED-9465, BED-9464, BED-9463

## How Has This Been Tested?

This has for the moment been tested in local lab instances. The lab instance was composed of various Active Directory site configurations:
- Single site
- 2 sites with associated subnets and 1 server by site
- 3 sites with several servers by site.

## Screenshots (if appropriate):

See the BloodHound PR and linked article for screenshots.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.

As was mentioned in the BloodHound pull request, this is of course only an implementation suggestion, and I remain open to discussion about the choices that were made, requests for implementation changes and so on! 

Cheers,


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Site** as a supported `--collectionmethods` option.
  * Added collection and export support for **Site**, **SiteServer**, and **SiteSubnet** data, including related containment details.
  * Included site data in generated output archives.

* **Bug Fixes**
  * Improved site subnet processing and security descriptor handling for more accurate results.

* **Documentation**
  * Updated CLI and PowerShell help to document the **Site** option and refreshed collection-method descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->