### PR TITLE
chore: update specterops nuget source to shcommon-nuget BED-8241

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
     <packageSources>
         <clear />
-        <add key="specterops" value="https://s3.amazonaws.com/bloodhound-ad/index.json" />
+        <add key="specterops" value="https://s3.amazonaws.com/shcommon-nuget/index.json" />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     </packageSources>
 </configuration>


### PR DESCRIPTION
## Description
Old bloodhound-ad s3 bucket has been replaced with new shcommon-nuget bucket for the specterops nuget feed. This pr updates nuget source to the new feed.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

This PR addresses: [BED-8241](https://specterops.atlassian.net/browse/BED-8241)

## How Has This Been Tested?
Ran `dotnet restore --no-cache`

## Screenshots (if appropriate):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Please make sure you have completed all following checks. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed

[BED-8241]: https://specterops.atlassian.net/browse/BED-8241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NuGet package source endpoint to improve package delivery reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->